### PR TITLE
Encoded ampersand characters in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -5,11 +5,11 @@
       version="0.0.3">
     <name>Cordova SMS Plugin</name>
     <author>Ramkumar Murugadoss</author>
-    <description>A SMS Plugin to enable to send & receive SMS on Cordova based Android App's by Ramkumar Murugadoss</description>
+    <description>A SMS Plugin to enable to send &amp; receive SMS on Cordova based Android App&apos;s by Ramkumar Murugadoss</description>
     <license>Apache 2.0</license>
     <keywords>cordova,sms,utils</keywords>
     <info>
-        A SMS Plugin to enable to send & receive SMS on Cordova based Android App's by Ramkumar Murugadoss
+        A SMS Plugin to enable to send &amp; receive SMS on Cordova based Android App's by Ramkumar Murugadoss
     </info>
 
     <engines>

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
       version="0.0.3">
     <name>Cordova SMS Plugin</name>
     <author>Ramkumar Murugadoss</author>
-    <description>A SMS Plugin to enable to send &amp; receive SMS on Cordova based Android App&apos;s by Ramkumar Murugadoss</description>
+    <description>A SMS Plugin to enable to send &amp; receive SMS on Cordova based Android Apps by Ramkumar Murugadoss</description>
     <license>Apache 2.0</license>
     <keywords>cordova,sms,utils</keywords>
     <info>


### PR DESCRIPTION
The & symbols tend to cause cordova to throw an "Invalid character in entity name" error.  Characters have been encoded.